### PR TITLE
Chef client 12.7.2 fix

### DIFF
--- a/providers/job_cleanup.rb
+++ b/providers/job_cleanup.rb
@@ -28,15 +28,7 @@ action :execute do
 
   if !jobs.nil? && !jobs.empty?
     # Get the diff between the real jobs and the defined jobs.
-    jobs_to_remove = if jobs.class == Array && new_resource.whitelist.class == String
-                       jobs - new_resource.whitelist.split(',')
-                     elsif jobs.class == String && new_resource.whitelist.class == String
-                       jobs.split(',') - new_resource.whitelist.split(',')
-                     elsif jobs.class == String && new_resource.whitelist.class == Array
-                       jobs.split(',') - new_resource.whitelist
-                     else
-                       jobs - new_resource.whitelist
-                     end
+    jobs_to_remove = jobs - new_resource.whitelist
     Chef::Log.debug("Jenkins jobs to remove: #{jobs_to_remove}")
   end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -6,8 +6,6 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-chef_gem 'chef-rewind'
-require 'chef/rewind'
 
 # Install Java.
 include_recipe 'java'

--- a/resources/job_cleanup.rb
+++ b/resources/job_cleanup.rb
@@ -20,4 +20,5 @@
 actions :execute
 default_action :execute
 
-attribute :whitelist, :name_attribute => true, :kind_of => Array, :required => true
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+attribute :whitelist, :kind_of => Array, :required => true

--- a/test/fixtures/cookbooks/jr-jenkins_job/recipes/update_no_verify.rb
+++ b/test/fixtures/cookbooks/jr-jenkins_job/recipes/update_no_verify.rb
@@ -13,6 +13,7 @@ end
 
 # Test jr_jenkins_job_cleanup
 chef_defined_jobs = ['testclient-core', 'testclient-salesforce']
-jr_jenkins_job_cleanup chef_defined_jobs do
+jr_jenkins_job_cleanup 'job_cleanup' do
+  whitelist chef_defined_jobs
   only_if { node['jr-hosted-springboard']['jenkins_job_cleanup'] }
 end


### PR DESCRIPTION
Fix jr-jenkins so it can work with chef-client 12.7.2.

Changes:

1. Prevent upstream from setting whitelist as name attribute, as this caused a bug that occasionally wiped all defined jobs at the end of the run. This was triggering warnings about Chef 13.
2. Revert some code that is no longer needed.
3. Update the test cookbook with the new whitelist attribute.